### PR TITLE
Make 'make verify' happy to enable Prow

### DIFF
--- a/cmd/csi-driver/main.go
+++ b/cmd/csi-driver/main.go
@@ -1,10 +1,27 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (
 	"os"
 
-	csidriver "github.com/cert-manager/trust-manager-csi-driver/internal/cmd/csi-driver"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+
+	csidriver "github.com/cert-manager/trust-manager-csi-driver/internal/cmd/csi-driver"
 )
 
 func main() {

--- a/demo/revert.sh
+++ b/demo/revert.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+# Copyright 2024 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -eu
 
 GREEN='\033[1;32m'

--- a/demo/step1.sh
+++ b/demo/step1.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+# Copyright 2024 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -eu
 
 GREEN='\033[1;32m'

--- a/demo/step2.sh
+++ b/demo/step2.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+# Copyright 2024 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -eu
 
 GREEN='\033[1;32m'

--- a/demo/teardown.sh
+++ b/demo/teardown.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+# Copyright 2024 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -eu
 
 kubectl delete namespace example 

--- a/deploy/charts/trust-manager-csi-driver/README.md
+++ b/deploy/charts/trust-manager-csi-driver/README.md
@@ -6,6 +6,11 @@
 
 <!-- AUTO-GENERATED -->
 
+#### **nameOverride** ~ `string`
+> Default value:
+> ```yaml
+> ""
+> ```
 #### **metrics.enabled** ~ `bool`
 > Default value:
 > ```yaml

--- a/deploy/charts/trust-manager-csi-driver/templates/daemonset.yaml
+++ b/deploy/charts/trust-manager-csi-driver/templates/daemonset.yaml
@@ -27,6 +27,8 @@ spec:
           {{- toYaml .Values.podAnnotations | nindent 8 }}
         {{- end }}
     spec:
+      securityContext:
+        seccompProfile: { type: RuntimeDefault }
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -37,6 +39,11 @@ spec:
       {{- end }}
       containers:
         - name: node-driver-registrar
+          securityContext:
+            runAsUser: 0
+            allowPrivilegeEscalation: false
+            capabilities: { drop: [ "ALL" ] }
+            readOnlyRootFilesystem: true
           image: "{{ template "image" (tuple .Values.nodeDriverRegistrarImage $.Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.nodeDriverRegistrarImage.pullPolicy }}
           args:
@@ -54,6 +61,11 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: liveness-probe
+          securityContext:
+            runAsUser: 0
+            allowPrivilegeEscalation: false
+            capabilities: { drop: [ "ALL" ] }
+            readOnlyRootFilesystem: true
           image: "{{ template "image" (tuple .Values.livenessProbeImage $.Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.livenessProbeImage.pullPolicy }}
           args:
@@ -66,20 +78,19 @@ spec:
               mountPath: /plugin
         - name: trust-manager-csi-driver
           securityContext:
-            readOnlyRootFilesystem: true
-            privileged: true
-            capabilities:
-              add: ["SYS_ADMIN"]
-            allowPrivilegeEscalation: true
             runAsUser: 0
+            privileged: true
+            capabilities: { drop: [ "ALL" ] }
+            readOnlyRootFilesystem: true
           image: "{{ template "image" (tuple .Values.image $.Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args :
-            - --node-id=$(NODE_ID)
             - --log-level={{ .Values.app.logLevel }}
             - --driver-name={{ .Values.app.driver.name }}
+            - --node-id=$(NODE_ID)
             - --endpoint=$(CSI_ENDPOINT)
             - --data-root=csi-data-dir
+            - --use-token-request={{ .Values.app.driver.useTokenRequest }}
             {{- if .Values.metrics.enabled }}
             - --metrics-bind-address=:{{ .Values.metrics.port }}
             {{- else }}

--- a/deploy/charts/trust-manager-csi-driver/values.schema.json
+++ b/deploy/charts/trust-manager-csi-driver/values.schema.json
@@ -30,6 +30,9 @@
         "metrics": {
           "$ref": "#/$defs/helm-values.metrics"
         },
+        "nameOverride": {
+          "$ref": "#/$defs/helm-values.nameOverride"
+        },
         "nodeDriverRegistrarImage": {
           "$ref": "#/$defs/helm-values.nodeDriverRegistrarImage"
         },
@@ -341,6 +344,10 @@
       "default": 9402,
       "description": "The TCP port on which the metrics server will listen.",
       "type": "number"
+    },
+    "helm-values.nameOverride": {
+      "default": "",
+      "type": "string"
     },
     "helm-values.nodeDriverRegistrarImage": {
       "additionalProperties": false,

--- a/deploy/charts/trust-manager-csi-driver/values.yaml
+++ b/deploy/charts/trust-manager-csi-driver/values.yaml
@@ -1,3 +1,5 @@
+nameOverride: ""
+
 metrics:
   # Enable the metrics server on csi-driver pods.
   # If false, the metrics server will be disabled and the other metrics fields below will be ignored.

--- a/internal/api/metadata/doc.go
+++ b/internal/api/metadata/doc.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // Package metadata contains the types used for storing volume metadata. The
 // unversioned types live in this package, with subpackages containing the
 // versioned types

--- a/internal/api/metadata/register.go
+++ b/internal/api/metadata/register.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package metadata
 
 import (

--- a/internal/api/metadata/types_metadata.go
+++ b/internal/api/metadata/types_metadata.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package metadata
 
 import (

--- a/internal/api/metadata/v1alpha1/doc.go
+++ b/internal/api/metadata/v1alpha1/doc.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // Package metadata contains the types used for storing volume metadata.
 
 // +kubebuilder:object:generate=true

--- a/internal/api/metadata/v1alpha1/register.go
+++ b/internal/api/metadata/v1alpha1/register.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package v1alpha1
 
 import (

--- a/internal/api/metadata/v1alpha1/types_metadata.go
+++ b/internal/api/metadata/v1alpha1/types_metadata.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package v1alpha1
 
 import (

--- a/internal/cmd/csi-driver/cmd.go
+++ b/internal/cmd/csi-driver/cmd.go
@@ -1,11 +1,25 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package csidriver
 
 import (
 	"fmt"
 
-	"github.com/cert-manager/trust-manager-csi-driver/internal/cmd/csi-driver/options"
-	"github.com/cert-manager/trust-manager-csi-driver/internal/driver"
-	"github.com/cert-manager/trust-manager-csi-driver/internal/scheme"
+	trustv1alpha1 "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -17,7 +31,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	trustv1alpha1 "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
+	"github.com/cert-manager/trust-manager-csi-driver/internal/cmd/csi-driver/options"
+	"github.com/cert-manager/trust-manager-csi-driver/internal/driver"
+	"github.com/cert-manager/trust-manager-csi-driver/internal/scheme"
 )
 
 const (

--- a/internal/cmd/csi-driver/options/options.go
+++ b/internal/cmd/csi-driver/options/options.go
@@ -1,14 +1,25 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package options
 
 import (
 	"flag"
 	"fmt"
 
-	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
-	// to ensure that exec-entrypoint and run can make use of them.
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
-
-	"github.com/cert-manager/trust-manager-csi-driver/internal/driver/config"
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -16,6 +27,12 @@ import (
 	"k8s.io/client-go/rest"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/klog/v2/textlogger"
+
+	"github.com/cert-manager/trust-manager-csi-driver/internal/driver/config"
+
+	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
+	// to ensure that exec-entrypoint and run can make use of them.
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 // Options are the main options for the approver-policy. Populated via
@@ -125,9 +142,8 @@ func (o *Options) addLogFlags(fs *pflag.FlagSet) {
 
 	// Walk over the log flags, merging onto the real flagset
 	logFs.VisitAll(func(flag *pflag.Flag) {
-		switch flag.Name {
 		// Translate the "v" flag to "log-level"
-		case "v":
+		if flag.Name == "v" {
 			flag.Name = "log-level"
 			flag.Usage = "Log level (1-5)."
 			fs.AddFlag(flag)

--- a/internal/driver/bundlewriter/bundleloader.go
+++ b/internal/driver/bundlewriter/bundleloader.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package bundlewriter
 
 import (

--- a/internal/driver/bundlewriter/bundlewriter.go
+++ b/internal/driver/bundlewriter/bundlewriter.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package bundlewriter
 
 import (

--- a/internal/driver/bundlewriter/filewriter.go
+++ b/internal/driver/bundlewriter/filewriter.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package bundlewriter
 
 import (
@@ -24,10 +40,10 @@ func NewAtomicFileWriter() FileWriter {
 type atomicWriter struct{}
 
 func (w atomicWriter) Write(ctx context.Context, target string, payload map[string]FileProjection) error {
-	atomicWriter, err := volumeutil.NewAtomicWriter(target)
+	atomicWriter, err := volumeutil.NewAtomicWriter(target, "trust-manager-csi-driver")
 	if err != nil {
 		return err
 	}
 
-	return atomicWriter.Write(ctx, payload, nil)
+	return atomicWriter.Write(payload, nil)
 }

--- a/internal/driver/config/config.go
+++ b/internal/driver/config/config.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package config
 
 import "path"

--- a/internal/driver/controller/controller.go
+++ b/internal/driver/controller/controller.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package controller
 
 import (

--- a/internal/driver/controller/setup.go
+++ b/internal/driver/controller/setup.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package controller
 
 import (

--- a/internal/driver/server/identityserver.go
+++ b/internal/driver/server/identityserver.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package server
 
 import (

--- a/internal/driver/server/setup.go
+++ b/internal/driver/server/setup.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package server
 
 import (
@@ -5,10 +21,6 @@ import (
 	"net"
 	"strings"
 
-	"github.com/cert-manager/trust-manager-csi-driver/internal/driver/bundlewriter"
-	"github.com/cert-manager/trust-manager-csi-driver/internal/driver/config"
-	"github.com/cert-manager/trust-manager-csi-driver/internal/driver/state"
-	"github.com/cert-manager/trust-manager-csi-driver/internal/version"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	grpcPrometheus "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
 	"github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
@@ -18,6 +30,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"github.com/cert-manager/trust-manager-csi-driver/internal/driver/bundlewriter"
+	"github.com/cert-manager/trust-manager-csi-driver/internal/driver/config"
+	"github.com/cert-manager/trust-manager-csi-driver/internal/driver/state"
+	"github.com/cert-manager/trust-manager-csi-driver/internal/version"
 )
 
 var grpcMetrics = grpcPrometheus.NewServerMetrics()
@@ -35,7 +52,9 @@ func Setup(mgr ctrl.Manager, config *config.Config, state *state.State, bw bundl
 			defer cancel()
 
 			// Create listener for the server
-			listener, err := net.Listen(parseEndpoint(config.GRPCEndpoint))
+			network, address := parseEndpoint(config.GRPCEndpoint)
+			lc := net.ListenConfig{}
+			listener, err := lc.Listen(ctx, network, address)
 			if err != nil {
 				return err
 			}

--- a/internal/driver/setup.go
+++ b/internal/driver/setup.go
@@ -1,8 +1,26 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package driver
 
 import (
 	"context"
 	"fmt"
+
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/cert-manager/trust-manager-csi-driver/internal/api/metadata"
 	"github.com/cert-manager/trust-manager-csi-driver/internal/api/metadata/v1alpha1"
@@ -11,7 +29,6 @@ import (
 	"github.com/cert-manager/trust-manager-csi-driver/internal/driver/controller"
 	"github.com/cert-manager/trust-manager-csi-driver/internal/driver/server"
 	"github.com/cert-manager/trust-manager-csi-driver/internal/driver/state"
-	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 func Setup(ctx context.Context, mgr ctrl.Manager, config *config.Config) error {

--- a/internal/driver/state/objectencoder.go
+++ b/internal/driver/state/objectencoder.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package state
 
 import (

--- a/internal/driver/state/state.go
+++ b/internal/driver/state/state.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package state
 
 import (
@@ -6,11 +22,12 @@ import (
 	"os"
 	"sync"
 
-	"github.com/cert-manager/trust-manager-csi-driver/internal/api/metadata"
-	"github.com/cert-manager/trust-manager-csi-driver/internal/driver/config"
 	"k8s.io/mount-utils"
 	"k8s.io/utils/set"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/cert-manager/trust-manager-csi-driver/internal/api/metadata"
+	"github.com/cert-manager/trust-manager-csi-driver/internal/driver/config"
 )
 
 // State contains the current state of the CSI implementation, it tracks the
@@ -117,6 +134,7 @@ func (s *State) Track(meta metadata.Metadata) error {
 
 	// Create the metadata.json file
 	metadataPath := s.config.MetadataPathForVolume(meta.VolumeID)
+	//nolint:gosec // FIXME: Review required permissions
 	if err := os.WriteFile(metadataPath, data, 0644); err != nil {
 		return fmt.Errorf("could not write metadata for volume %q: %w", meta.VolumeID, err)
 	}

--- a/internal/scheme/scheme.go
+++ b/internal/scheme/scheme.go
@@ -1,11 +1,28 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package scheme
 
 import (
-	"github.com/cert-manager/trust-manager-csi-driver/internal/api/metadata"
-	metadatav1alpha1 "github.com/cert-manager/trust-manager-csi-driver/internal/api/metadata/v1alpha1"
 	trustv1alpha1 "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubernetes "k8s.io/client-go/kubernetes/scheme"
+
+	"github.com/cert-manager/trust-manager-csi-driver/internal/api/metadata"
+	metadatav1alpha1 "github.com/cert-manager/trust-manager-csi-driver/internal/api/metadata/v1alpha1"
 )
 
 func New() *runtime.Scheme {

--- a/internal/utils/x509/hash.go
+++ b/internal/utils/x509/hash.go
@@ -1,6 +1,23 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package x509
 
 import (
+	//nolint:gosec // used to generate the exact same hash as openssl so the filenames match
 	"crypto/sha1"
 	"crypto/x509"
 	"encoding/asn1"
@@ -22,6 +39,7 @@ func CertificateSubjectHash(cert *x509.Certificate) (string, error) {
 		return "", err
 	}
 
+	//nolint:gosec // used to generate the exact same hash as openssl so the filenames match
 	hashed := sha1.Sum(value.Bytes)
 	encoded := hex.EncodeToString(hashed[:4])
 	return encoded[6:8] + encoded[4:6] + encoded[2:4] + encoded[0:2], nil

--- a/internal/utils/x509/hash_test.go
+++ b/internal/utils/x509/hash_test.go
@@ -1,8 +1,23 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package x509_test
 
 import (
 	"crypto/x509"
-	_ "embed"
 	"encoding/pem"
 	"fmt"
 	"os"
@@ -11,6 +26,8 @@ import (
 	"testing"
 
 	x509util "github.com/cert-manager/trust-manager-csi-driver/internal/utils/x509"
+
+	_ "embed"
 )
 
 //go:embed testdata/cacert.pem

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package version
 
 import (

--- a/make/00_mod.mk
+++ b/make/00_mod.mk
@@ -1,3 +1,17 @@
+# Copyright 2024 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 repo_name := github.com/cert-manager/trust-manager-csi-driver
 
 # Trust manager version used for testing

--- a/make/02_mod.mk
+++ b/make/02_mod.mk
@@ -1,3 +1,17 @@
+# Copyright 2024 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 include make/test-e2e.mk
 include make/test-unit.mk
 

--- a/make/test-e2e.mk
+++ b/make/test-e2e.mk
@@ -1,3 +1,16 @@
+# Copyright 2024 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 .PHONY: e2e-setup-trust-manager
 e2e-setup-trust-manager: e2e-setup-cert-manager | kind-cluster $(NEEDS_HELM)

--- a/make/test-unit.mk
+++ b/make/test-unit.mk
@@ -1,3 +1,17 @@
+# Copyright 2024 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 .PHONY: test-unit
 ## Unit tests
 ## @category Testing

--- a/make/verify-pod-security-standards-exceptions.yaml
+++ b/make/verify-pod-security-standards-exceptions.yaml
@@ -1,0 +1,23 @@
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: ignore
+spec:
+  exceptions:
+  - policyName: disallow-host-path
+    ruleNames: [ autogen-host-path ]
+  - policyName: disallow-privilege-escalation
+    ruleNames: [ autogen-privilege-escalation ]
+  - policyName: disallow-privileged-containers
+    ruleNames: [ autogen-privileged-containers ]
+  - policyName: require-run-as-non-root-user
+    ruleNames: [ autogen-run-as-non-root-user ]
+  - policyName: require-run-as-nonroot
+    ruleNames: [ autogen-run-as-non-root ]
+  - policyName: restrict-volume-types
+    ruleNames: [ autogen-restricted-volumes ]
+  match:
+    any:
+    - resources:
+        kinds:
+        - DaemonSet

--- a/third_party/k8s.io/kubernetes/pkg/volume/util/atomic_writer_linux.go
+++ b/third_party/k8s.io/kubernetes/pkg/volume/util/atomic_writer_linux.go
@@ -19,13 +19,9 @@ limitations under the License.
 
 package util
 
-import (
-	"os"
-
-	"github.com/go-logr/logr"
-)
+import "os"
 
 // chown changes the numeric uid and gid of the named file.
-func (w *AtomicWriter) chown(_ logr.Logger, name string, uid, gid int) error {
+func (w *AtomicWriter) chown(name string, uid, gid int) error {
 	return os.Chown(name, uid, gid)
 }

--- a/third_party/k8s.io/kubernetes/pkg/volume/util/atomic_writer_unsupported.go
+++ b/third_party/k8s.io/kubernetes/pkg/volume/util/atomic_writer_unsupported.go
@@ -22,12 +22,12 @@ package util
 import (
 	"runtime"
 
-	"github.com/go-logr/logr"
+	"k8s.io/klog/v2"
 )
 
 // chown changes the numeric uid and gid of the named file.
 // This is a no-op on unsupported platforms.
-func (w *AtomicWriter) chown(logger logr.Logger, path string, uid, gid int) error {
-	logger.Info("skipping change of Linux owner on unsupported OS", "path", path, "os", runtime.GOOS, "uid", uid, "gid", gid)
+func (w *AtomicWriter) chown(name string, uid, _ /* gid */ int) error {
+	klog.Warningf("%s: skipping change of Linux owner %v for file %s; unsupported on %s", w.logContext, uid, name, runtime.GOOS)
 	return nil
 }


### PR DESCRIPTION
Before enabling Prow, I think we should make some targets typically run by Prow happy. The `verify` make target needed some love.